### PR TITLE
Bump version to 0.2.2.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 setup(name='gevent-kafka',
-      version='0.0',
+      version='0.2.2',
       description='ApacheKafka bindings for gevent',
       author='Johan Rydberg',
       author_email='johan.rydberg@gmail.com',


### PR DESCRIPTION
Make `pip freeze` happy, i.e. will show `gevent-kafka==0.2.2` instead of `gevent-kafka==0.0`.

And I chose 0.2.2 because that's the release we're using according to https://github.com/edgeware/gevent-kafka/releases
