### PR TITLE
Handle None data from kazoo

### DIFF
--- a/gevent_kafka/monitor.py
+++ b/gevent_kafka/monitor.py
@@ -31,7 +31,7 @@ def zkmonitor(kazoo, path, into, watch=None, factory=json.loads):
 
     def update_child(child, data, stat, event=None):
         try:
-            if event and event.type == EventType.DELETED:
+            if (event and event.type == EventType.DELETED) or data is None:
                 into.pop(child, None)
                 return False  # stops the watcher
             into[child] = factory(data)


### PR DESCRIPTION
According to Kazoo docs, data will be None if znode is gone, so treat like delete. Without this, there will be trouble in factory methods that don't expect None arguments.
