### PR TITLE
Kafka consumer reliability 23252

### DIFF
--- a/gevent_kafka/consumer.py
+++ b/gevent_kafka/consumer.py
@@ -218,13 +218,10 @@ class ConsumedTopic(object):
             else:
                 if messages:
                     try:
-                        failure = self.callback(messages)
-                        if failure:
-                            self.log.warn("Consumer callback reported failure: %s" % failure)
+                        self.callback(messages)
                     except Exception as e:
                         self.log.error("Consumer callback failed: %s" % e)
-                        failure = True
-                    if not failure:
+                    else:
                         self.offsets[bpid] += delta
                         self.update_offset(bpid, self.offsets[bpid])
                 else:


### PR DESCRIPTION
Currently, errors in the callbacks of kafka message consumers kill the message
consumption loop. This commit catches and logs consumer callback errors. It
also introduces the option of returning a truthy value from the callback to
signal that the message set was not fully processed, and that the consumer
offset thus should not be updated. A falsy value is used to indicate success
in order to keep the behavior of current call sites.
