### PR TITLE
Allow skip tests

### DIFF
--- a/gevent_kafka/test/test_monitor.py
+++ b/gevent_kafka/test/test_monitor.py
@@ -57,7 +57,7 @@ def keep_trying(fun, exception=AssertionError, timeout=1.0, delay=0.1):
             break
 
 
-class GeventKafkaMonitorTestCase(KazooTestCase):
+class GeventKafkaMonitorTestCase(KazooTestCase, unittest.TestCase):
 
     """Unit tests for the ZooKeeper monitor."""
 


### PR DESCRIPTION
Running these tests under Python2.6 with unittest2 doesn't properly skip the tests if `$ZOOKEEPER_PATH` isn't present without inheriting from `unittest.TestCase`.
