### PR TITLE
Use laxer install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@
 from sys import version_info
 from setuptools import setup, find_packages
 
-tests_require = ['mock==1.0.1']
+tests_require = ['mock']
 
 if version_info < (2, 7):
-    tests_require.append('unittest2==0.5.1')
+    tests_require.append('unittest2')
 
 setup(name='gevent-kafka',
       version='0.3.0',
@@ -16,7 +16,7 @@ setup(name='gevent-kafka',
       packages=find_packages(),
       test_suite='gevent_kafka.test',
       install_requires=[
-          'gevent==1.0.1',
-          'kazoo==1.3.1'
+          'gevent>=1.0.1',
+          'kazoo>=1.3.1'
       ],
       tests_require=tests_require)


### PR DESCRIPTION
It's up the application to govern what version of dependencies it wants, just set some ground rules of dependencies needed and minimum version.

Mostly because this doesn't align what what we have in our `requirements.txt` file, and the version of gevent, and kazoo doesn't matter much for this library.

@edgeware/convoy 
